### PR TITLE
Percentile fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@
 - `TeleOpCore` snapshots initial gamepad state through framework pre-init plumbing, not through subclass `super.onInitialize()` calls.
 - `Hardware` is now per-opmode, not global static state. Do not reintroduce the old `Hardware.init(...)` mental model.
 - Several opmodes keep subsystem references in static fields and explicitly reset them on init. That is intentional protection against stale state across FTC opmode reruns.
-- `@Configurable` is an annotation used on classes to expose `public static` tuning fields at runtime from the Control Hub web interface. These fields are live development surfaces and often matter more than hard-coded defaults in the file.
+- `utilities/LiveMatchTuning.java` is the only intended `@Configurable` surface. Keep it scalar-only and match-facing; do not add `@Configurable` back to mechanisms, subsystems, autos, or classes with complex object fields unless the Sloth patch-application cost has been reconsidered.
 
 ## Active Control Surfaces
 
@@ -66,6 +66,8 @@
   Source of truth for how autonomous initialization, firing readiness, obelisk acquisition assist, and path-step execution currently work.
 - `drive/pedroPathing/Constants.java`
   Shared follower and drivetrain tuning that affects both teleop follower-assisted behavior and autonomous.
+- `utilities/LiveMatchTuning.java`
+  Runtime Control Hub tuning for current match-facing scalar values. Autonomous path/plan constants are code-patched rather than exposed as live configurables.
 
 ## State Machines And Coordinators
 

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -7,13 +7,17 @@
 // the build definitions, you can place those customizations in this file, but
 // please think carefully as to whether such customizations are really necessary
 // before doing so.
-
+//
 
 // Custom definitions may go here
 
 // Include common definitions from above.
 apply from: '../build.common.gradle'
 apply from: '../build.dependencies.gradle'
+
+// Sloth must be applied AFTER build.common.gradle because that file applies
+// the Android plugin and creates AndroidComponentsExtension.
+apply plugin: 'dev.frozenmilk.sinister.sloth.load'
 
 android {
     namespace = 'org.firstinspires.ftc.teamcode'

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Collector.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Collector.java
@@ -1,11 +1,9 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import org.firstinspires.ftc.teamcode.hardware.SmartMotor;
 import org.firstinspires.ftc.teamcode.utilities.Direction;
 
-@Configurable
 public class Collector {
     private final SmartMotor motor;
     public static Direction direction = Direction.REVERSE;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/DriveBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/DriveBase.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.pedropathing.Drivetrain;
 import com.pedropathing.follower.Follower;
 import com.pedropathing.ftc.drivetrains.Mecanum;
@@ -11,15 +10,11 @@ import org.firstinspires.ftc.teamcode.drive.DriveBaseMotorConfig;
 import org.firstinspires.ftc.teamcode.drive.pedroPathing.Constants;
 import org.firstinspires.ftc.teamcode.utilities.Pose;
 
-@Configurable
 public class DriveBase {
 
     private final Drivetrain drivetrain;
     private final Localizer localizer;
     private Follower follower;
-    public static float TRANSLATIONAL_VELOCITY_MULTIPLIER = 40f;
-    public static float HEADING_VELOCITY_MULTIPLIER = 3f;
-
     private double powerFactor = 1;
 
     public static DriveMotorPosition zeroIndex = DriveMotorPosition.LEFT_FRONT;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/FeedRamp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/FeedRamp.java
@@ -1,24 +1,17 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.hardware.SmartServo;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
-@Configurable
 public class FeedRamp {
     SmartServo leftFeedServo, rightFeedServo;
 
     private double targetPosition;
 
-    public static double min = 0;
-    public static double max = 1;
-
-    public static double engagedPosition = 0.32;
-    public static double disengagedPosition = 1;
-
     public FeedRamp(SmartServo leftServo, SmartServo rightServo) {
         leftFeedServo = leftServo;
         rightFeedServo = rightServo;
-        setTargetPosition(disengagedPosition);
+        setTargetPosition(LiveMatchTuning.feedRampDisengagedPosition);
     }
 
     public void setTargetPosition(double position) {
@@ -39,19 +32,19 @@ public class FeedRamp {
     }
 
     public void engage(){
-        setTargetPosition(engagedPosition);
+        setTargetPosition(LiveMatchTuning.feedRampEngagedPosition);
     }
 
     public void disengage(){
-        setTargetPosition(disengagedPosition);
+        setTargetPosition(LiveMatchTuning.feedRampDisengagedPosition);
     }
 
     public boolean isEngaged(){
-        return targetPosition == engagedPosition;
+        return targetPosition == LiveMatchTuning.feedRampEngagedPosition;
     }
 
     private double clamp(double value){
-        return clamp(value, min, max);
+        return clamp(value, LiveMatchTuning.feedRampMin, LiveMatchTuning.feedRampMax);
     }
 
     private double clamp(double value, double min, double max){

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/FeedWheels.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/FeedWheels.java
@@ -1,12 +1,10 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.hardware.CRServo;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
-@Configurable
 public class FeedWheels {
     private final CRServo leftServo, rightServo;
-    public static double power = 1;
 
     public FeedWheels(CRServo leftServo, CRServo rightServo) {
         this.leftServo = leftServo;
@@ -14,8 +12,8 @@ public class FeedWheels {
     }
 
     public void start(){
-        leftServo.setPower(power);
-        rightServo.setPower(power);
+        leftServo.setPower(LiveMatchTuning.feedWheelPower);
+        rightServo.setPower(LiveMatchTuning.feedWheelPower);
     }
 
     public void stop(){

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Hood.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Hood.java
@@ -1,9 +1,7 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.hardware.SmartServo;
 
-@Configurable
 public class Hood {
     private final SmartServo servo;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Indexer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Indexer.java
@@ -1,31 +1,26 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.components.MotorPositionAxisComponent;
 import org.firstinspires.ftc.teamcode.hardware.SmartMotor;
 import org.firstinspires.ftc.teamcode.hardware.controllers.PID;
 import org.firstinspires.ftc.teamcode.utilities.Direction;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
-@Configurable
 public class Indexer extends MotorPositionAxisComponent {
-
-    public static double kP = 0.007, kI = 0, kD = 0.0075, kF = 0.000005, tolerance = 1, busyTolerance = 2.5;
-    public static double poweredMovePower = 1;
-    public static float ticksPerDegree = 8192f/360f;
 
     private boolean poweredApproachActive = false;
     private double poweredApproachDirection = 0;
-    private double poweredApproachPower = poweredMovePower;
+    private double poweredApproachPower = LiveMatchTuning.indexerPoweredMovePower;
 
     public Indexer(SmartMotor motor) {
         super(
                 motor,
                 PID.builder()
-                .setKP(() -> kP)
-                .setKI(() -> kI)
-                .setKD(() -> kD)
-                .setKF(() -> kF)
-                .setTolerance(tolerance)
+                .setKP(() -> LiveMatchTuning.indexerKp)
+                .setKI(() -> LiveMatchTuning.indexerKi)
+                .setKD(() -> LiveMatchTuning.indexerKd)
+                .setKF(() -> LiveMatchTuning.indexerKf)
+                .setTolerance(LiveMatchTuning.indexerToleranceDeg)
                 .setDirectionalKF(true)
                 .build()
         );
@@ -37,7 +32,7 @@ public class Indexer extends MotorPositionAxisComponent {
 
     @Override
     public boolean isBusy() {
-        return Math.abs(getCurrentPosition() - getTargetPosition()) > busyTolerance;
+        return Math.abs(getCurrentPosition() - getTargetPosition()) > LiveMatchTuning.indexerBusyToleranceDeg;
     }
 
     @Override
@@ -53,7 +48,7 @@ public class Indexer extends MotorPositionAxisComponent {
 
     @Override
     public double getCurrentPosition() {
-        return motor.getCurrentPosition() / ticksPerDegree;
+        return motor.getCurrentPosition() / LiveMatchTuning.indexerTicksPerDegree;
     }
 
     public long getCurrentIndex(){
@@ -104,7 +99,7 @@ public class Indexer extends MotorPositionAxisComponent {
     }
 
     public void advanceIndexClockwiseWithPower() {
-        advanceIndexClockwiseWithPower(1, poweredMovePower);
+        advanceIndexClockwiseWithPower(1, LiveMatchTuning.indexerPoweredMovePower);
     }
 
     public void advanceIndexClockwiseWithPower(double power) {
@@ -116,7 +111,7 @@ public class Indexer extends MotorPositionAxisComponent {
     }
 
     public void advanceIndexCounterclockwiseWithPower() {
-        advanceIndexCounterclockwiseWithPower(1, poweredMovePower);
+        advanceIndexCounterclockwiseWithPower(1, LiveMatchTuning.indexerPoweredMovePower);
     }
 
     public void advanceIndexCounterclockwiseWithPower(double power) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Launcher.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Launcher.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import org.firstinspires.ftc.robotcore.external.navigation.VoltageUnit;
 import org.firstinspires.ftc.teamcode.components.MotorVelocityAxisComponent;
@@ -9,16 +8,12 @@ import org.firstinspires.ftc.teamcode.hardware.SmartMotor;
 import org.firstinspires.ftc.teamcode.hardware.controllers.VelocityPID;
 import org.firstinspires.ftc.teamcode.hardware.filters.DataFilter;
 import org.firstinspires.ftc.teamcode.hardware.filters.RollingAverage;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
-@Configurable
 public class Launcher extends MotorVelocityAxisComponent {
     private final Hardware hardware;
 
-    public static double kP = 0.002, kI = 0, kD = 0, kF = 0.00025, kV = 0.03, tolerance = 30;
-    public static double maxVoltage = 14;
     private final DataFilter voltageFilter = new RollingAverage(100);
-
-    public static float ticksPerDegree = (112f/360f);
 
     private boolean runMaxPower = false;
 
@@ -26,11 +21,11 @@ public class Launcher extends MotorVelocityAxisComponent {
         super(
                 motor,
                 VelocityPID.builder()
-                        .setKP(() -> kP)
-                        .setKI(() -> kI)
-                        .setKD(() -> kD)
-                        .setKF(() -> kF)
-                        .setTolerance(tolerance)
+                        .setKP(() -> LiveMatchTuning.launcherKp)
+                        .setKI(() -> LiveMatchTuning.launcherKi)
+                        .setKD(() -> LiveMatchTuning.launcherKd)
+                        .setKF(() -> LiveMatchTuning.launcherKf)
+                        .setTolerance(LiveMatchTuning.launcherTolerance)
                         .build()
         );
         this.hardware = hardware;
@@ -39,11 +34,11 @@ public class Launcher extends MotorVelocityAxisComponent {
 
     @Override
     protected double shapeMotorPower(double output, double target, double current) {
-        if(runMaxPower && (target + tolerance * 2) - current > tolerance ) {
+        if(runMaxPower && (target + LiveMatchTuning.launcherTolerance * 2) - current > LiveMatchTuning.launcherTolerance ) {
             return 1;
         }
         double voltageCompensation = target != 0
-                ? (maxVoltage - voltageFilter.compute(hardware.getControlHub().getInputVoltage(VoltageUnit.VOLTS))) * kV
+                ? (LiveMatchTuning.launcherMaxVoltage - voltageFilter.compute(hardware.getControlHub().getInputVoltage(VoltageUnit.VOLTS))) * LiveMatchTuning.launcherKv
                 : 0;
         return output + voltageCompensation;
     }
@@ -64,7 +59,7 @@ public class Launcher extends MotorVelocityAxisComponent {
 
     @Override
     public double getCurrentVelocity() {
-        return motor.getVelocity() / ticksPerDegree;
+        return motor.getVelocity() / LiveMatchTuning.launcherTicksPerDegree;
     }
 
     public double getVelocity() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/LimelightLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/LimelightLocalizer.java
@@ -1,28 +1,14 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
-import org.firstinspires.ftc.teamcode.components.subsystems.FireControlSystem;
 import org.firstinspires.ftc.teamcode.hardware.SmartLimelight3A;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 import org.firstinspires.ftc.teamcode.utilities.Pose;
 
-@Configurable
 public class LimelightLocalizer {
     private final SmartLimelight3A limelight;
     private Pose lastPose = new Pose(0, 0, 0);
     private Pose lastRelPose = new Pose(0, 0, 0);
     private String lastSolveStatus = "No solve yet";
-
-    /**
-     * The camera pose in the launcher frame, in inches/degrees.
-     * X is forward, Y is right, and heading is positive counter-clockwise from launcher forward.
-     */
-    public static double CAMERA_X = 0, CAMERA_Y = 0, CAMERA_Z = 0, CAMERA_HEADING = 0;
-
-    /**
-     * Known depot tag headings in the field frame, in degrees. These are configurable because the
-     * field position alone is not enough to solve the launcher's heading from one tag detection.
-     */
-    public static double BLUE_DEPOT_HEADING = -40, RED_DEPOT_HEADING = 40;
 
     private static final double INCHES_PER_METER = 39.37007874015748;
     private static final double MIN_TAG_RANGE_INCHES = 1.0;
@@ -63,14 +49,14 @@ public class LimelightLocalizer {
 
         lastRelPose = tagRelPose;
 
-        double tagFieldX = FireControlSystem.BLUE_DEPOT_X;
-        double tagFieldY = FireControlSystem.BLUE_DEPOT_Y;
-        double tagFieldHeading = BLUE_DEPOT_HEADING;
+        double tagFieldX = LiveMatchTuning.blueDepotX;
+        double tagFieldY = LiveMatchTuning.blueDepotY;
+        double tagFieldHeading = LiveMatchTuning.blueDepotHeadingDeg;
 
         if (tag.type() == SmartLimelight3A.AprilTag.Type.RED_DEPOT) {
-            tagFieldX = FireControlSystem.RED_DEPOT_X;
-            tagFieldY = FireControlSystem.RED_DEPOT_Y;
-            tagFieldHeading = RED_DEPOT_HEADING;
+            tagFieldX = LiveMatchTuning.redDepotX;
+            tagFieldY = LiveMatchTuning.redDepotY;
+            tagFieldHeading = LiveMatchTuning.redDepotHeadingDeg;
         }
 
         Pose tagFieldPose = new Pose(tagFieldX, tagFieldY, tagFieldHeading);
@@ -81,7 +67,14 @@ public class LimelightLocalizer {
     }
 
     public Pose getCameraPose() {
-        return new Pose(CAMERA_X, CAMERA_Y, CAMERA_Z, CAMERA_HEADING, 0, 0);
+        return new Pose(
+                LiveMatchTuning.limelightLocalizerCameraX,
+                LiveMatchTuning.limelightLocalizerCameraY,
+                LiveMatchTuning.limelightLocalizerCameraZ,
+                LiveMatchTuning.limelightLocalizerCameraHeadingDeg,
+                0,
+                0
+        );
     }
 
     public String getLastSolveStatus() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Turret.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/mechanisms/Turret.java
@@ -1,30 +1,25 @@
 package org.firstinspires.ftc.teamcode.components.mechanisms;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.components.MotorPositionAxisComponent;
 import org.firstinspires.ftc.teamcode.hardware.SmartEncoder;
 import org.firstinspires.ftc.teamcode.hardware.SmartMotor;
 import org.firstinspires.ftc.teamcode.hardware.controllers.PID;
 import org.firstinspires.ftc.teamcode.utilities.Direction;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
-@Configurable
 public class Turret extends MotorPositionAxisComponent {
     private final SmartEncoder encoder;
-    public static double kP = 0.02, kI = 0, kD = 0.015, kF = 0, tolerance = 1;
-    public static float ticksPerDegree = (8192f / 360f) * (88f / 20f);
-    public static double minAngle = -90;
-    public static double maxAngle = 90;
     private double desiredTarget;
 
     public Turret(SmartMotor motor, SmartEncoder encoder) {
         super(
                 motor,
                 PID.builder()
-                        .setKP(() -> kP)
-                        .setKI(() -> kI)
-                        .setKD(() -> kD)
-                        .setKF(() -> kF)
-                        .setTolerance(tolerance)
+                        .setKP(() -> LiveMatchTuning.turretKp)
+                        .setKI(() -> LiveMatchTuning.turretKi)
+                        .setKD(() -> LiveMatchTuning.turretKd)
+                        .setKF(() -> LiveMatchTuning.turretKf)
+                        .setTolerance(LiveMatchTuning.turretToleranceDeg)
                         .setDirectionalKF(true)
                         .build()
         );
@@ -41,7 +36,7 @@ public class Turret extends MotorPositionAxisComponent {
 
     @Override
     public double getCurrentPosition() {
-        return encoder.getPosition() / ticksPerDegree;
+        return encoder.getPosition() / LiveMatchTuning.turretTicksPerDegree;
     }
 
     @Override
@@ -52,7 +47,7 @@ public class Turret extends MotorPositionAxisComponent {
 
     @Override
     protected double normalizeTargetPosition(double targetPosition) {
-        return clamp(targetPosition, minAngle, maxAngle);
+        return clamp(targetPosition, LiveMatchTuning.turretMinAngleDeg, LiveMatchTuning.turretMaxAngleDeg);
     }
 
     public double getDesiredTarget(){

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/FireControlSystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/FireControlSystem.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.components.subsystems;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.components.mechanisms.DriveBase;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Hood;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Launcher;
@@ -9,18 +8,11 @@ import org.firstinspires.ftc.teamcode.core.OpModeCore;
 import org.firstinspires.ftc.teamcode.core.implementations.AutonomousConfiguration;
 import org.firstinspires.ftc.teamcode.hardware.SmartLEDIndicator;
 import org.firstinspires.ftc.teamcode.hardware.SmartLimelight3A;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 import org.firstinspires.ftc.teamcode.utilities.MatchStateStore;
 import org.firstinspires.ftc.teamcode.utilities.Pose;
 
-@Configurable
 public class FireControlSystem {
-    public static double baseVelocity = 2700, kVDist = 620, minVelocity = 3500;
-    public static double hoodBasePos = 0.53, kHoodDist = 0.1;
-    public static boolean useDepotPoseFallbackWhenTagNotVisible = true;
-    public static double alignedButLauncherOffHueDeg = 145.0;
-    public static double BLUE_DEPOT_X = 59, BLUE_DEPOT_Y = 57;
-    public static double RED_DEPOT_X = 59, RED_DEPOT_Y = -57;
-    public static double TURRET_TOLERANCE = 3;
     private final Turret turret;
     private final Hood hood;
     private final Launcher launcher;
@@ -34,7 +26,6 @@ public class FireControlSystem {
     private boolean turretAutoAimEnabled = true;
     private State state;
     private boolean runLauncher = false;
-    public static double maxVelocity = 5000;
     public static double bearingToDepot = 0;
     private boolean firing = false;
 
@@ -91,9 +82,12 @@ public class FireControlSystem {
                 if (turretAutoAimEnabled) {
                     setTurretTargetClosestFacing(turret.getCurrentPosition() + bearingToDepot);
                 }
-                hood.setTargetPosition(hoodBasePos + kHoodDist * depot.distanceXYToTagMeters());
+                hood.setTargetPosition(LiveMatchTuning.fcsHoodBasePosition + LiveMatchTuning.fcsHoodPositionPerMeter * depot.distanceXYToTagMeters());
                 if (runLauncher) {
-                    launcher.setTargetVelocity(Math.min(Math.max(baseVelocity + depot.distanceXYToTagMeters() * kVDist, minVelocity), maxVelocity));
+                    launcher.setTargetVelocity(Math.min(Math.max(
+                            LiveMatchTuning.fcsBaseVelocity + depot.distanceXYToTagMeters() * LiveMatchTuning.fcsVelocityPerMeter,
+                            LiveMatchTuning.fcsMinVelocity
+                    ), LiveMatchTuning.fcsMaxVelocity));
                 }
             } catch (IllegalStateException e) {
                 OpModeCore.getTelemetry().warning("Getting April Tag Bearing failed: " + e.getMessage());
@@ -109,7 +103,7 @@ public class FireControlSystem {
             } else if (firing) {
                 led.setPulseWidthMicros(1350);
             } else if (!runLauncher && turretAligned) {
-                led.setHue(alignedButLauncherOffHueDeg);
+                led.setHue(LiveMatchTuning.fcsAlignedButLauncherOffHueDeg);
             } else if(state != null) {
                 led.setColor(state.color);
             } else {
@@ -127,7 +121,7 @@ public class FireControlSystem {
     }
 
     public boolean isTurretAligned(){
-        return Math.abs(turret.getCurrentPosition() - turret.getDesiredTarget()) <= TURRET_TOLERANCE;
+        return Math.abs(turret.getCurrentPosition() - turret.getDesiredTarget()) <= LiveMatchTuning.fcsTurretToleranceDeg;
     }
 
     public boolean isLauncherRunning(){
@@ -179,7 +173,7 @@ public class FireControlSystem {
 
     private void aimTowardDepotPoseIfConfigured() {
         Pose targetDepotPose = getTargetDepotPose();
-        if (!useDepotPoseFallbackWhenTagNotVisible || driveBase == null || targetDepotPose == null) {
+        if (!LiveMatchTuning.fcsUseDepotPoseFallbackWhenTagNotVisible || driveBase == null || targetDepotPose == null) {
             return;
         }
 
@@ -195,8 +189,11 @@ public class FireControlSystem {
         if (turretAutoAimEnabled) {
             setTurretTargetClosestFacing(relativeBearingDeg);
         }
-        hood.setTargetPosition(hoodBasePos + kHoodDist * (Math.hypot(deltaX, deltaY)) / 39.37);
-        launcher.setTargetVelocity(Math.max(minVelocity, baseVelocity + kVDist * Math.hypot(deltaX, deltaY) / 39.37));
+        hood.setTargetPosition(LiveMatchTuning.fcsHoodBasePosition + LiveMatchTuning.fcsHoodPositionPerMeter * (Math.hypot(deltaX, deltaY)) / 39.37);
+        launcher.setTargetVelocity(Math.max(
+                LiveMatchTuning.fcsMinVelocity,
+                LiveMatchTuning.fcsBaseVelocity + LiveMatchTuning.fcsVelocityPerMeter * Math.hypot(deltaX, deltaY) / 39.37
+        ));
     }
 
     private Pose getTargetDepotPose() {
@@ -204,9 +201,9 @@ public class FireControlSystem {
             return depotPose;
         }
         if (allianceColor == MatchStateStore.AllianceColor.RED) {
-            return new Pose(RED_DEPOT_X, RED_DEPOT_Y);
+            return new Pose(LiveMatchTuning.redDepotX, LiveMatchTuning.redDepotY);
         }
-        return new Pose(BLUE_DEPOT_X, BLUE_DEPOT_Y);
+        return new Pose(LiveMatchTuning.blueDepotX, LiveMatchTuning.blueDepotY);
     }
 
     private SmartLimelight3A.AprilTag getAllianceDepotTag() {
@@ -225,8 +222,8 @@ public class FireControlSystem {
         double nearestFacing = selectClosestEquivalentAngle(
                 nominalFacingAngleDeg,
                 currentAngleDeg,
-                Turret.minAngle,
-                Turret.maxAngle
+                LiveMatchTuning.turretMinAngleDeg,
+                LiveMatchTuning.turretMaxAngleDeg
         );
         turret.setTargetPosition(nearestFacing);
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/IndexerStorage.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/IndexerStorage.java
@@ -1,21 +1,15 @@
 package org.firstinspires.ftc.teamcode.components.subsystems;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Indexer;
 import org.firstinspires.ftc.teamcode.hardware.ScoringElementColor;
 import org.firstinspires.ftc.teamcode.hardware.SmartColorSensor;
 import org.firstinspires.ftc.teamcode.hardware.SmartLEDIndicator;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
 import java.util.Arrays;
 
-@Configurable
 public class IndexerStorage {
-    public static int requiredConsecutiveContentReads = 1;
-    public static double frontSensorMinDistance = 38;
-    public static double GREEN_HUE = 159.0;
-    public static double PURPLE_HUE = 170.0;
-
     public enum SlotContent {
         OPEN,
         GREEN,
@@ -73,8 +67,8 @@ public class IndexerStorage {
     }
 
     public String getFrontClosestColorMatch() {
-        double greenDist = Math.abs(getFrontSensorHue() - GREEN_HUE);
-        double purpleDist = Math.abs(getFrontSensorHue() - PURPLE_HUE);
+        double greenDist = Math.abs(getFrontSensorHue() - LiveMatchTuning.greenHue);
+        double purpleDist = Math.abs(getFrontSensorHue() - LiveMatchTuning.purpleHue);
 
         if (greenDist < purpleDist) {
             return "ARTIFACT_GREEN";
@@ -115,7 +109,7 @@ public class IndexerStorage {
     }
 
     public boolean isFrontFull(){
-        return frontColorSensor.getDistance(DistanceUnit.MM) < frontSensorMinDistance;
+        return frontColorSensor.getDistance(DistanceUnit.MM) < LiveMatchTuning.frontSensorMinDistance;
     }
 
     public void updateIndexerContent() {
@@ -130,7 +124,7 @@ public class IndexerStorage {
             frontDetectionStreak = 1;
         }
 
-        if (frontDetectionStreak < Math.max(1, requiredConsecutiveContentReads)) {
+        if (frontDetectionStreak < Math.max(1, LiveMatchTuning.requiredConsecutiveContentReads)) {
             return;
         }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/SingleFireStorageManager.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/SingleFireStorageManager.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.components.subsystems;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Collector;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Indexer;
@@ -8,7 +7,6 @@ import org.firstinspires.ftc.teamcode.components.mechanisms.Indexer;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
-@Configurable
 public class SingleFireStorageManager {
     private final FeedSystem feeder;
     private final Indexer indexer;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/VolleyFireStorageManager.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/components/subsystems/VolleyFireStorageManager.java
@@ -1,15 +1,14 @@
 package org.firstinspires.ftc.teamcode.components.subsystems;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Collector;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Indexer;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
 import java.util.ArrayDeque;
 import java.util.Objects;
 import java.util.Queue;
 
-@Configurable
 public class VolleyFireStorageManager {
     private final FeedSystem feeder;
     private final Indexer indexer;
@@ -19,15 +18,9 @@ public class VolleyFireStorageManager {
     private State state;
     private long lastFireIndex = 0;
     private final ElapsedTime firePrepareTimer = new ElapsedTime();
-    public static double FIRE_PREPARE_TIME_MS = 250;
-    public static double FIRE_END_TIME_MS = 350;
     private final FireControlSystem fcs;
 
     // jam correcting
-        public static boolean JAM_CORRECTING_ENABLED = true;
-        public static double JAM_CORRECTING_TIME_THRESHOLD = 300;
-        public static double JAM_CORRECTING_VELOCITY_THRESHOLD = 25;
-        public static double JAM_CORRECTING_TIME_MS = 1000;
         private boolean isJamCorrecting = false;
         private long lastTarget = 0;
         private final ElapsedTime jamTimer = new ElapsedTime(), activeJamTimer = new ElapsedTime();;
@@ -57,11 +50,11 @@ public class VolleyFireStorageManager {
         indexer.tick();
         indexerStorage.tick();
 
-        if(JAM_CORRECTING_ENABLED){
+        if(LiveMatchTuning.volleyJamCorrectingEnabled){
             checkForIndexerJam();
         }
 
-        if (isJamCorrecting && (!indexer.isBusy() || activeJamTimer.milliseconds() > JAM_CORRECTING_TIME_MS)) {
+        if (isJamCorrecting && (!indexer.isBusy() || activeJamTimer.milliseconds() > LiveMatchTuning.volleyJamCorrectingTimeMs)) {
             isJamCorrecting = false;
             indexer.setTargetIndex(lastTarget);
             return;
@@ -106,7 +99,7 @@ public class VolleyFireStorageManager {
             } break;
 
             case ENGAGING_FEEDER: {
-                if(firePrepareTimer.milliseconds() > FIRE_PREPARE_TIME_MS){
+                if(firePrepareTimer.milliseconds() > LiveMatchTuning.volleyFirePrepareTimeMs){
                     indexerStorage.dropFreshFlag();
                     state = State.FIRING;
                     lastFireIndex = indexer.getCurrentIndex();
@@ -129,7 +122,7 @@ public class VolleyFireStorageManager {
             } break;
 
             case ENDING_FIRING: {
-                if(firePrepareTimer.milliseconds() > FIRE_END_TIME_MS){
+                if(firePrepareTimer.milliseconds() > LiveMatchTuning.volleyFireEndTimeMs){
                     state = State.RESTING;
                     feeder.stopFeeding();
                     fcs.setFiring(false);
@@ -139,8 +132,8 @@ public class VolleyFireStorageManager {
     }
 
     private void checkForIndexerJam() {
-        if (indexer.isBusy() && Math.abs(indexer.getVelocity()) <= JAM_CORRECTING_VELOCITY_THRESHOLD && !isJamCorrecting) {
-            if (jamTimer.milliseconds() > JAM_CORRECTING_TIME_THRESHOLD) {
+        if (indexer.isBusy() && Math.abs(indexer.getVelocity()) <= LiveMatchTuning.volleyJamCorrectingVelocityThreshold && !isJamCorrecting) {
+            if (jamTimer.milliseconds() > LiveMatchTuning.volleyJamCorrectingTimeThresholdMs) {
                 jamTimer.reset();
                 activeJamTimer.reset();
                 lastTarget = indexer.getTargetIndex();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/AutonomousConfiguration.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/AutonomousConfiguration.java
@@ -1,9 +1,7 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.utilities.MatchStateStore;
 
-@Configurable
 public final class AutonomousConfiguration {
     public static boolean runFCS = true;
     public static double targetVelocity = 2000;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Blue1VolleyFarAuto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Blue1VolleyFarAuto.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
@@ -13,7 +12,6 @@ import org.firstinspires.ftc.teamcode.utilities.MatchStateStore;
 import java.util.ArrayList;
 import java.util.List;
 
-@Configurable
 @Autonomous(name = "2 - Blue 1 Volley Far")
 public class Blue1VolleyFarAuto extends AutoOpBase {
     public static double START_X = -60.9;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Blue3VolleyCloseAuto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Blue3VolleyCloseAuto.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
@@ -16,7 +15,6 @@ import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-@Configurable
 @Autonomous(name = "1 - Blue 3 Volley Close")
 public class Blue3VolleyCloseAuto extends AutoOpBase {
     public static double START_X = 54.7;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/LimelightDiagnosticsTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/LimelightDiagnosticsTeleOp.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.teamcode.core.SmartGamepad;
 import org.firstinspires.ftc.teamcode.core.TeleOpCore;
@@ -11,7 +10,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Configurable
 @TeleOp(name = "4 - Limelight Diagnostics")
 public class LimelightDiagnosticsTeleOp extends TeleOpCore {
     public static String limelightName = "limelight";

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
@@ -22,10 +22,10 @@ import org.firstinspires.ftc.teamcode.hardware.SmartCameraColorSensor;
 import org.firstinspires.ftc.teamcode.hardware.SmartColorSensor;
 import org.firstinspires.ftc.teamcode.hardware.SmartLEDIndicator;
 import org.firstinspires.ftc.teamcode.hardware.SmartLimelight3A;
-import org.firstinspires.ftc.teamcode.hardware.filters.DataFilter;
 import org.firstinspires.ftc.teamcode.hardware.filters.RollingAverage;
 import org.firstinspires.ftc.teamcode.utilities.Direction;
 import org.firstinspires.ftc.teamcode.utilities.MatchStateStore;
+import org.firstinspires.ftc.teamcode.utilities.RollingPercentileWindow;
 
 @Configurable
 @TeleOp(name = "1 - Main TeleOp")
@@ -47,7 +47,10 @@ public class MainTeleOp extends TeleOpCore {
     protected static SmartLimelight3A limelight;
     protected static Limelight3A limelight3A;
     protected ElapsedTime tickTimer = new ElapsedTime();
-    protected DataFilter tickTimeFilter = new RollingAverage(10);
+    protected RollingAverage tickTimeAverage = new RollingAverage(10);
+    protected RollingPercentileWindow tickTimePercentiles = new RollingPercentileWindow(200);
+    protected double lastTickTimeMs = 0;
+    protected double maxObservedTickTimeMs = 0;
 
 
     public static double launchVelocity = 2150;
@@ -55,6 +58,7 @@ public class MainTeleOp extends TeleOpCore {
     public static double matchStateFreshnessMs = 10000;
     public static double matchStateSaveIntervalMs = 500;
     public static double teleOpFollowerMaxPower = 1.0;
+    public static int tickTimePercentileWindow = 200;
     public static MatchStateStore.AllianceColor defaultAllianceColor = MatchStateStore.AllianceColor.BLUE;
     public static double indexerZeroBumpTicksPerTriggerUnit = 20.0;
     public static double turretZeroBumpTicksPerTriggerUnit = -200.0;
@@ -106,6 +110,10 @@ public class MainTeleOp extends TeleOpCore {
         teleOpTaskManager = null;
         clearLeftSlotWhenFeederReturns = false;
         runFCS = true;
+        tickTimeAverage = new RollingAverage(10);
+        tickTimePercentiles = new RollingPercentileWindow(Math.max(1, tickTimePercentileWindow));
+        lastTickTimeMs = 0;
+        maxObservedTickTimeMs = 0;
 
         DriveBaseMotorConfig.DriveBaseMotorConfigBuilder configBuilder = new DriveBaseMotorConfig.DriveBaseMotorConfigBuilder();
         configBuilder.leftFront("LFront", Direction.FORWARD);
@@ -391,6 +399,17 @@ public class MainTeleOp extends TeleOpCore {
         }
 
         persistMatchStateIfDue(false);
+        recordTickTimeSample();
+    }
+
+    private void recordTickTimeSample() {
+        double tickTimeMs = tickTimer.milliseconds();
+        lastTickTimeMs = tickTimeMs;
+        tickTimeAverage.compute(tickTimeMs);
+        tickTimePercentiles.compute(tickTimeMs);
+        if (tickTimeMs > maxObservedTickTimeMs) {
+            maxObservedTickTimeMs = tickTimeMs;
+        }
     }
 
     private void applyPersistedPoseIfAvailable() {
@@ -441,7 +460,14 @@ public class MainTeleOp extends TeleOpCore {
     }
 
     private void registerDebugTelemetry() {
-        prettyTelem.addData("Tick Time", () -> tickTimeFilter.compute(tickTimer.milliseconds()));
+        prettyTelem.addLine("Loop Timing")
+                .addData("Last Tick (ms)", () -> lastTickTimeMs)
+                .addData("Avg Tick (ms)", tickTimeAverage::getAverage)
+                .addData("P50 (ms)", () -> tickTimePercentiles.getPercentile(50))
+                .addData("P95 (ms)", () -> tickTimePercentiles.getPercentile(95))
+                .addData("P99 (ms)", () -> tickTimePercentiles.getPercentile(99))
+                .addData("Max Tick (ms)", () -> maxObservedTickTimeMs)
+                .addData("Samples", tickTimePercentiles::size);
 
         prettyTelem.addLine("Match")
                 .addData("Alliance", () -> allianceColor.name())

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.hardware.limelightvision.Limelight3A;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.CRServo;
@@ -25,9 +24,9 @@ import org.firstinspires.ftc.teamcode.hardware.SmartLimelight3A;
 import org.firstinspires.ftc.teamcode.hardware.filters.DataFilter;
 import org.firstinspires.ftc.teamcode.hardware.filters.RollingAverage;
 import org.firstinspires.ftc.teamcode.utilities.Direction;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 import org.firstinspires.ftc.teamcode.utilities.MatchStateStore;
 
-@Configurable
 @TeleOp(name = "1 - Main TeleOp")
 public class MainTeleOp extends TeleOpCore {
     protected static DriveBase driveBase;
@@ -50,20 +49,9 @@ public class MainTeleOp extends TeleOpCore {
     protected DataFilter tickTimeFilter = new RollingAverage(10);
 
 
-    public static double launchVelocity = 2150;
-    public static boolean runFCS = true;
-    public static double matchStateFreshnessMs = 10000;
-    public static double matchStateSaveIntervalMs = 500;
-    public static double teleOpFollowerMaxPower = 1.0;
-    public static MatchStateStore.AllianceColor defaultAllianceColor = MatchStateStore.AllianceColor.BLUE;
-    public static double indexerZeroBumpTicksPerTriggerUnit = 20.0;
-    public static double turretZeroBumpTicksPerTriggerUnit = -200.0;
-    public static SmartLEDIndicator.IndicatorColor turretZeroTrimLedColor = SmartLEDIndicator.IndicatorColor.INDIGO;
-    public static SmartLEDIndicator.IndicatorColor manualAimLedColor = SmartLEDIndicator.IndicatorColor.YELLOW;
-    public static double maintenancePoseTrimInchesPerTouchpadUnit = 12.0;
-    public static double manualAimDegreesPerSecond = 75.0;
-    public static double manualAimStickDeadband = 0.08;
-    private MatchStateStore.AllianceColor allianceColor = defaultAllianceColor;
+    private static final SmartLEDIndicator.IndicatorColor TURRET_ZERO_TRIM_LED_COLOR = SmartLEDIndicator.IndicatorColor.INDIGO;
+    private static final SmartLEDIndicator.IndicatorColor MANUAL_AIM_LED_COLOR = SmartLEDIndicator.IndicatorColor.YELLOW;
+    private MatchStateStore.AllianceColor allianceColor = defaultAllianceColor();
     private MatchStateStore.Snapshot startupSnapshot;
     private boolean loadedFreshSnapshot = false;
     private long lastMatchStateSaveMs = 0;
@@ -71,7 +59,12 @@ public class MainTeleOp extends TeleOpCore {
     private TeleOpTaskManager teleOpTaskManager;
     private boolean manualAimMode = false;
     private double manualAimTargetDeg = 0;
-    public static boolean clearLeftSlotWhenFeederReturns = false;
+    private static MatchStateStore.AllianceColor defaultAllianceColor() {
+        return MatchStateStore.parseAllianceColor(
+                LiveMatchTuning.defaultAllianceColor,
+                MatchStateStore.AllianceColor.BLUE
+        );
+    }
 
     private static void resetSubsystemReferences() {
         if (limelight != null) {
@@ -103,7 +96,8 @@ public class MainTeleOp extends TeleOpCore {
     protected void onInitialize(){
         //noinspection DuplicatedCode
         resetSubsystemReferences();
-        startupSnapshot = MatchStateStore.getFreshSnapshot(Math.max(1000L, (long) matchStateFreshnessMs));
+        MatchStateStore.AllianceColor defaultAllianceColor = defaultAllianceColor();
+        startupSnapshot = MatchStateStore.getFreshSnapshot(Math.max(1000L, (long) LiveMatchTuning.matchStateFreshnessMs));
         allianceColor = startupSnapshot != null
                 ? MatchStateStore.parseAllianceColor(startupSnapshot.allianceColor, defaultAllianceColor)
                 : defaultAllianceColor;
@@ -113,8 +107,7 @@ public class MainTeleOp extends TeleOpCore {
         teleOpTaskManager = null;
         manualAimMode = false;
         manualAimTargetDeg = 0;
-        clearLeftSlotWhenFeederReturns = false;
-        runFCS = true;
+        LiveMatchTuning.runTeleOpFcs = true;
 
         DriveBaseMotorConfig.DriveBaseMotorConfigBuilder configBuilder = new DriveBaseMotorConfig.DriveBaseMotorConfigBuilder();
         configBuilder.leftFront("LFront", Direction.FORWARD);
@@ -122,7 +115,7 @@ public class MainTeleOp extends TeleOpCore {
         configBuilder.rightFront("RFront", Direction.REVERSE);
         configBuilder.rightRear("RRear", Direction.FORWARD);
 
-        Constants.setMecanumMaxPower(teleOpFollowerMaxPower);
+        Constants.setMecanumMaxPower(LiveMatchTuning.teleOpFollowerMaxPower);
 
         try {
             feedWheels = new FeedWheels(
@@ -231,9 +224,9 @@ public class MainTeleOp extends TeleOpCore {
         double driveX = -gamepad1.leftStickX;
         double driveY = -gamepad1.leftStickY;
         double driveTurn = -gamepad1.rightStickX;
-        boolean hasDriverOverrideInput = Math.abs(driveX) > TeleOpTaskManager.driverOverrideDeadband
-                || Math.abs(driveY) > TeleOpTaskManager.driverOverrideDeadband
-                || Math.abs(driveTurn) > TeleOpTaskManager.driverOverrideDeadband;
+        boolean hasDriverOverrideInput = Math.abs(driveX) > LiveMatchTuning.driverOverrideDeadband
+                || Math.abs(driveY) > LiveMatchTuning.driverOverrideDeadband
+                || Math.abs(driveTurn) > LiveMatchTuning.driverOverrideDeadband;
 
         boolean turretTrimActive = false;
 
@@ -380,11 +373,11 @@ public class MainTeleOp extends TeleOpCore {
             volleyStorageManager.tick();
         }
 
-        if(fcs != null && runFCS){
+        if(fcs != null && LiveMatchTuning.runTeleOpFcs){
             try {
                 fcs.tick();
             } catch (Exception e) {
-                runFCS = false;
+                LiveMatchTuning.runTeleOpFcs = false;
                 String message = e.getMessage();
                 prettyTelem.error("FCS tick failed; disabling FCS. " +
                         e.getClass().getSimpleName() +
@@ -439,7 +432,7 @@ public class MainTeleOp extends TeleOpCore {
 
     private void persistMatchStateIfDue(boolean force) {
         long now = System.currentTimeMillis();
-        long intervalMs = Math.max(100L, (long) matchStateSaveIntervalMs);
+        long intervalMs = Math.max(100L, (long) LiveMatchTuning.teleOpMatchStateSaveIntervalMs);
         if (!force && now - lastMatchStateSaveMs < intervalMs) {
             return;
         }
@@ -552,11 +545,11 @@ public class MainTeleOp extends TeleOpCore {
         lastManualAimUpdateMs = nowMs;
 
         double input = gamepad.rightTrigger - gamepad.leftTrigger;
-        if (Math.abs(input) <= manualAimStickDeadband) {
+        if (Math.abs(input) <= LiveMatchTuning.manualAimStickDeadband) {
             return;
         }
 
-        manualAimTargetDeg += input * manualAimDegreesPerSecond * elapsedSec;
+        manualAimTargetDeg += input * LiveMatchTuning.manualAimDegreesPerSecond * elapsedSec;
         turret.setTargetPosition(manualAimTargetDeg);
         manualAimTargetDeg = turret.getTargetPosition();
     }
@@ -569,7 +562,7 @@ public class MainTeleOp extends TeleOpCore {
         double triggerDelta = gamepad.rightTrigger - gamepad.leftTrigger;
         if (gamepad.leftBumper && turret != null) {
             if (Math.abs(triggerDelta) > 1e-6) {
-                int turretBump = (int) (triggerDelta * turretZeroBumpTicksPerTriggerUnit);
+                int turretBump = (int) (triggerDelta * LiveMatchTuning.turretZeroBumpTicksPerTriggerUnit);
                 if (turretBump != 0) {
                     turret.bumpZero(turretBump);
                 }
@@ -582,7 +575,7 @@ public class MainTeleOp extends TeleOpCore {
         }
 
         if (indexer != null) {
-            int indexerBump = (int) (triggerDelta * indexerZeroBumpTicksPerTriggerUnit);
+            int indexerBump = (int) (triggerDelta * LiveMatchTuning.indexerZeroBumpTicksPerTriggerUnit);
             if (indexerBump != 0) {
                 indexer.bumpZero(indexerBump);
             }
@@ -595,9 +588,9 @@ public class MainTeleOp extends TeleOpCore {
             return;
         }
         if (turretTrimActive) {
-            fcs.setLedOverrideColor(turretZeroTrimLedColor);
+            fcs.setLedOverrideColor(TURRET_ZERO_TRIM_LED_COLOR);
         } else if (manualAimMode) {
-            fcs.setLedOverrideColor(manualAimLedColor);
+            fcs.setLedOverrideColor(MANUAL_AIM_LED_COLOR);
         } else {
             fcs.setLedOverrideColor(null);
         }
@@ -615,7 +608,7 @@ public class MainTeleOp extends TeleOpCore {
         }
 
         com.pedropathing.geometry.Pose currentPose = driveBase.getFollower().getPose();
-        double trimScale = maintenancePoseTrimInchesPerTouchpadUnit;
+        double trimScale = LiveMatchTuning.maintenancePoseTrimInchesPerTouchpadUnit;
         double newX = currentPose.getX() + (deltaX * trimScale);
         double newY = currentPose.getY() - (deltaY * trimScale);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
@@ -50,6 +50,9 @@ public class MainTeleOp extends TeleOpCore {
     protected RollingPercentileWindow tickTimePercentiles = new RollingPercentileWindow(200);
     protected double lastTickTimeMs = 0;
     protected double maxObservedTickTimeMs = 0;
+    protected double tickTimeP50Ms = 0;
+    protected double tickTimeP95Ms = 0;
+    protected double tickTimeP99Ms = 0;
 
 
     private static final SmartLEDIndicator.IndicatorColor TURRET_ZERO_TRIM_LED_COLOR = SmartLEDIndicator.IndicatorColor.INDIGO;
@@ -126,6 +129,9 @@ public class MainTeleOp extends TeleOpCore {
         tickTimePercentiles = new RollingPercentileWindow(Math.max(1, tickTimePercentileWindow));
         lastTickTimeMs = 0;
         maxObservedTickTimeMs = 0;
+        tickTimeP50Ms = 0;
+        tickTimeP95Ms = 0;
+        tickTimeP99Ms = 0;
         manualAimMode = false;
         manualAimTargetDeg = 0;
         LiveMatchTuning.runTeleOpFcs = true;
@@ -427,7 +433,11 @@ public class MainTeleOp extends TeleOpCore {
         double tickTimeMs = tickTimer.milliseconds();
         lastTickTimeMs = tickTimeMs;
         tickTimeAverage.compute(tickTimeMs);
-        tickTimePercentiles.compute(tickTimeMs);
+        tickTimePercentiles.add(tickTimeMs);
+        double[] percentiles = tickTimePercentiles.getPercentiles(50, 95, 99);
+        tickTimeP50Ms = percentiles[0];
+        tickTimeP95Ms = percentiles[1];
+        tickTimeP99Ms = percentiles[2];
         if (tickTimeMs > maxObservedTickTimeMs) {
             maxObservedTickTimeMs = tickTimeMs;
         }
@@ -484,9 +494,9 @@ public class MainTeleOp extends TeleOpCore {
         prettyTelem.addLine("Loop Timing")
                 .addData("Last Tick (ms)", () -> lastTickTimeMs)
                 .addData("Avg Tick (ms)", tickTimeAverage::getAverage)
-                .addData("P50 (ms)", () -> tickTimePercentiles.getPercentile(50))
-                .addData("P95 (ms)", () -> tickTimePercentiles.getPercentile(95))
-                .addData("P99 (ms)", () -> tickTimePercentiles.getPercentile(99))
+                .addData("P50 (ms)", () -> tickTimeP50Ms)
+                .addData("P95 (ms)", () -> tickTimeP95Ms)
+                .addData("P99 (ms)", () -> tickTimeP99Ms)
                 .addData("Max Tick (ms)", () -> maxObservedTickTimeMs)
                 .addData("Samples", tickTimePercentiles::size);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
@@ -21,11 +21,11 @@ import org.firstinspires.ftc.teamcode.hardware.SmartCameraColorSensor;
 import org.firstinspires.ftc.teamcode.hardware.SmartColorSensor;
 import org.firstinspires.ftc.teamcode.hardware.SmartLEDIndicator;
 import org.firstinspires.ftc.teamcode.hardware.SmartLimelight3A;
-import org.firstinspires.ftc.teamcode.hardware.filters.DataFilter;
 import org.firstinspires.ftc.teamcode.hardware.filters.RollingAverage;
 import org.firstinspires.ftc.teamcode.utilities.Direction;
 import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 import org.firstinspires.ftc.teamcode.utilities.MatchStateStore;
+import org.firstinspires.ftc.teamcode.utilities.RollingPercentileWindow;
 
 @TeleOp(name = "1 - Main TeleOp")
 public class MainTeleOp extends TeleOpCore {
@@ -46,12 +46,27 @@ public class MainTeleOp extends TeleOpCore {
     protected static SmartLimelight3A limelight;
     protected static Limelight3A limelight3A;
     protected ElapsedTime tickTimer = new ElapsedTime();
-    protected DataFilter tickTimeFilter = new RollingAverage(10);
+    protected RollingAverage tickTimeAverage = new RollingAverage(10);
+    protected RollingPercentileWindow tickTimePercentiles = new RollingPercentileWindow(200);
+    protected double lastTickTimeMs = 0;
+    protected double maxObservedTickTimeMs = 0;
 
 
     private static final SmartLEDIndicator.IndicatorColor TURRET_ZERO_TRIM_LED_COLOR = SmartLEDIndicator.IndicatorColor.INDIGO;
     private static final SmartLEDIndicator.IndicatorColor MANUAL_AIM_LED_COLOR = SmartLEDIndicator.IndicatorColor.YELLOW;
     private MatchStateStore.AllianceColor allianceColor = defaultAllianceColor();
+    public static double launchVelocity = 2150;
+    public static boolean runFCS = true;
+    public static double matchStateFreshnessMs = 10000;
+    public static double matchStateSaveIntervalMs = 500;
+    public static double teleOpFollowerMaxPower = 1.0;
+    public static int tickTimePercentileWindow = 200;
+    public static MatchStateStore.AllianceColor defaultAllianceColor = MatchStateStore.AllianceColor.BLUE;
+    public static double indexerZeroBumpTicksPerTriggerUnit = 20.0;
+    public static double turretZeroBumpTicksPerTriggerUnit = -200.0;
+    public static SmartLEDIndicator.IndicatorColor turretZeroTrimLedColor = SmartLEDIndicator.IndicatorColor.INDIGO;
+    public static double maintenancePoseTrimInchesPerTouchpadUnit = 12.0;
+    private MatchStateStore.AllianceColor allianceColor = defaultAllianceColor;
     private MatchStateStore.Snapshot startupSnapshot;
     private boolean loadedFreshSnapshot = false;
     private long lastMatchStateSaveMs = 0;
@@ -105,6 +120,12 @@ public class MainTeleOp extends TeleOpCore {
         lastMatchStateSaveMs = 0;
         lastManualAimUpdateMs = System.currentTimeMillis();
         teleOpTaskManager = null;
+        clearLeftSlotWhenFeederReturns = false;
+        runFCS = true;
+        tickTimeAverage = new RollingAverage(10);
+        tickTimePercentiles = new RollingPercentileWindow(Math.max(1, tickTimePercentileWindow));
+        lastTickTimeMs = 0;
+        maxObservedTickTimeMs = 0;
         manualAimMode = false;
         manualAimTargetDeg = 0;
         LiveMatchTuning.runTeleOpFcs = true;
@@ -397,6 +418,19 @@ public class MainTeleOp extends TeleOpCore {
                 driveBase.getFollower().updatePose();
             }
         }
+
+        persistMatchStateIfDue(false);
+        recordTickTimeSample();
+    }
+
+    private void recordTickTimeSample() {
+        double tickTimeMs = tickTimer.milliseconds();
+        lastTickTimeMs = tickTimeMs;
+        tickTimeAverage.compute(tickTimeMs);
+        tickTimePercentiles.compute(tickTimeMs);
+        if (tickTimeMs > maxObservedTickTimeMs) {
+            maxObservedTickTimeMs = tickTimeMs;
+        }
     }
 
     private void applyPersistedPoseIfAvailable() {
@@ -447,7 +481,14 @@ public class MainTeleOp extends TeleOpCore {
     }
 
     private void registerDebugTelemetry() {
-        prettyTelem.addData("Tick Time", () -> tickTimeFilter.compute(tickTimer.milliseconds()));
+        prettyTelem.addLine("Loop Timing")
+                .addData("Last Tick (ms)", () -> lastTickTimeMs)
+                .addData("Avg Tick (ms)", tickTimeAverage::getAverage)
+                .addData("P50 (ms)", () -> tickTimePercentiles.getPercentile(50))
+                .addData("P95 (ms)", () -> tickTimePercentiles.getPercentile(95))
+                .addData("P99 (ms)", () -> tickTimePercentiles.getPercentile(99))
+                .addData("Max Tick (ms)", () -> maxObservedTickTimeMs)
+                .addData("Samples", tickTimePercentiles::size);
 
         prettyTelem.addLine("Match")
                 .addData("Alliance", () -> allianceColor.name())

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
@@ -69,7 +69,6 @@ public class MainTeleOp extends TeleOpCore {
     public static double turretZeroBumpTicksPerTriggerUnit = -200.0;
     public static SmartLEDIndicator.IndicatorColor turretZeroTrimLedColor = SmartLEDIndicator.IndicatorColor.INDIGO;
     public static double maintenancePoseTrimInchesPerTouchpadUnit = 12.0;
-    private MatchStateStore.AllianceColor allianceColor = defaultAllianceColor;
     private MatchStateStore.Snapshot startupSnapshot;
     private boolean loadedFreshSnapshot = false;
     private long lastMatchStateSaveMs = 0;
@@ -123,7 +122,6 @@ public class MainTeleOp extends TeleOpCore {
         lastMatchStateSaveMs = 0;
         lastManualAimUpdateMs = System.currentTimeMillis();
         teleOpTaskManager = null;
-        clearLeftSlotWhenFeederReturns = false;
         runFCS = true;
         tickTimeAverage = new RollingAverage(10);
         tickTimePercentiles = new RollingPercentileWindow(Math.max(1, tickTimePercentileWindow));

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/MainTeleOp.java
@@ -51,6 +51,9 @@ public class MainTeleOp extends TeleOpCore {
     protected RollingPercentileWindow tickTimePercentiles = new RollingPercentileWindow(200);
     protected double lastTickTimeMs = 0;
     protected double maxObservedTickTimeMs = 0;
+    protected double tickTimeP50Ms = 0;
+    protected double tickTimeP95Ms = 0;
+    protected double tickTimeP99Ms = 0;
 
 
     public static double launchVelocity = 2150;
@@ -114,6 +117,9 @@ public class MainTeleOp extends TeleOpCore {
         tickTimePercentiles = new RollingPercentileWindow(Math.max(1, tickTimePercentileWindow));
         lastTickTimeMs = 0;
         maxObservedTickTimeMs = 0;
+        tickTimeP50Ms = 0;
+        tickTimeP95Ms = 0;
+        tickTimeP99Ms = 0;
 
         DriveBaseMotorConfig.DriveBaseMotorConfigBuilder configBuilder = new DriveBaseMotorConfig.DriveBaseMotorConfigBuilder();
         configBuilder.leftFront("LFront", Direction.FORWARD);
@@ -406,7 +412,11 @@ public class MainTeleOp extends TeleOpCore {
         double tickTimeMs = tickTimer.milliseconds();
         lastTickTimeMs = tickTimeMs;
         tickTimeAverage.compute(tickTimeMs);
-        tickTimePercentiles.compute(tickTimeMs);
+        tickTimePercentiles.add(tickTimeMs);
+        double[] percentiles = tickTimePercentiles.getPercentiles(50, 95, 99);
+        tickTimeP50Ms = percentiles[0];
+        tickTimeP95Ms = percentiles[1];
+        tickTimeP99Ms = percentiles[2];
         if (tickTimeMs > maxObservedTickTimeMs) {
             maxObservedTickTimeMs = tickTimeMs;
         }
@@ -463,9 +473,9 @@ public class MainTeleOp extends TeleOpCore {
         prettyTelem.addLine("Loop Timing")
                 .addData("Last Tick (ms)", () -> lastTickTimeMs)
                 .addData("Avg Tick (ms)", tickTimeAverage::getAverage)
-                .addData("P50 (ms)", () -> tickTimePercentiles.getPercentile(50))
-                .addData("P95 (ms)", () -> tickTimePercentiles.getPercentile(95))
-                .addData("P99 (ms)", () -> tickTimePercentiles.getPercentile(99))
+                .addData("P50 (ms)", () -> tickTimeP50Ms)
+                .addData("P95 (ms)", () -> tickTimeP95Ms)
+                .addData("P99 (ms)", () -> tickTimeP99Ms)
                 .addData("Max Tick (ms)", () -> maxObservedTickTimeMs)
                 .addData("Samples", tickTimePercentiles::size);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Red1VolleyFarAuto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Red1VolleyFarAuto.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
@@ -12,7 +11,6 @@ import org.firstinspires.ftc.teamcode.utilities.MatchStateStore;
 import java.util.ArrayList;
 import java.util.List;
 
-@Configurable
 @Autonomous(name = "2 - Red 1 Volley Far")
 public class Red1VolleyFarAuto extends AutoOpBase {
     public static double START_X = -60.9;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Red3VolleyCloseAuto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/Red3VolleyCloseAuto.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
@@ -17,7 +16,6 @@ import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-@Configurable
 @Autonomous(name = "1 - Red 3 Volley Close")
 public class Red3VolleyCloseAuto extends AutoOpBase {
     public static double START_X = 54.7;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/SimpleTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/implementations/SimpleTeleOp.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.core.implementations;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.CRServo;
 import org.firstinspires.ftc.teamcode.components.mechanisms.*;
@@ -10,7 +9,6 @@ import org.firstinspires.ftc.teamcode.core.TeleOpCore;
 import org.firstinspires.ftc.teamcode.drive.DriveBaseMotorConfig;
 import org.firstinspires.ftc.teamcode.utilities.Direction;
 
-@Configurable
 @TeleOp(name = "2 - Simple TeleOp")
 public class SimpleTeleOp extends TeleOpCore {
     protected static DriveBase driveBase;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/teleoptasks/TeleOpTaskManager.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/core/teleoptasks/TeleOpTaskManager.java
@@ -1,24 +1,9 @@
 package org.firstinspires.ftc.teamcode.core.teleoptasks;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.core.teleoptasks.tasks.FarFiringTask;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 
-@Configurable
 public class TeleOpTaskManager {
-    public static double farFiringTaskBaseBlueXIn = -55.5;
-    public static double farFiringTaskBaseBlueYIn = -48;
-    public static double farFiringTaskBaseBlueHeadingDeg = -105;
-    public static double farFiringTaskBaseRedXIn = -55.5;
-    public static double farFiringTaskBaseRedYIn = 48;
-    public static double farFiringTaskBaseRedHeadingDeg = 105;
-    public static double farFiringTaskDriveToBaseTimeoutSec = 4.0;
-    public static double farFiringTaskWaitForFullTimeoutSec = 10.0;
-    public static double farFiringTaskReturnTimeoutSec = 4.0;
-    public static double farFiringTaskReadyToFireTimeoutSec = 4.0;
-    public static double farFiringTaskStorageDrainTimeoutSec = 10.0;
-    public static double farFiringTaskRepeatDelaySec = 0.5;
-    public static double driverOverrideDeadband = 0.08;
-
     private final TeleOpTaskContext context;
     private TeleOpTask activeTask;
     private String lastExitReason = "NONE";
@@ -45,18 +30,18 @@ public class TeleOpTaskManager {
 
     public boolean startFarFiringTask() {
         return start(new FarFiringTask(
-                farFiringTaskBaseBlueXIn,
-                farFiringTaskBaseBlueYIn,
-                farFiringTaskBaseBlueHeadingDeg,
-                farFiringTaskBaseRedXIn,
-                farFiringTaskBaseRedYIn,
-                farFiringTaskBaseRedHeadingDeg,
-                farFiringTaskDriveToBaseTimeoutSec,
-                farFiringTaskWaitForFullTimeoutSec,
-                farFiringTaskReturnTimeoutSec,
-                farFiringTaskReadyToFireTimeoutSec,
-                farFiringTaskStorageDrainTimeoutSec,
-                farFiringTaskRepeatDelaySec
+                LiveMatchTuning.farFiringTaskBaseBlueXIn,
+                LiveMatchTuning.farFiringTaskBaseBlueYIn,
+                LiveMatchTuning.farFiringTaskBaseBlueHeadingDeg,
+                LiveMatchTuning.farFiringTaskBaseRedXIn,
+                LiveMatchTuning.farFiringTaskBaseRedYIn,
+                LiveMatchTuning.farFiringTaskBaseRedHeadingDeg,
+                LiveMatchTuning.farFiringTaskDriveToBaseTimeoutSec,
+                LiveMatchTuning.farFiringTaskWaitForFullTimeoutSec,
+                LiveMatchTuning.farFiringTaskReturnTimeoutSec,
+                LiveMatchTuning.farFiringTaskReadyToFireTimeoutSec,
+                LiveMatchTuning.farFiringTaskStorageDrainTimeoutSec,
+                LiveMatchTuning.farFiringTaskRepeatDelaySec
         ));
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/pedroPathing/Constants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/pedroPathing/Constants.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.drive.pedroPathing;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.pedropathing.follower.Follower;
 import com.pedropathing.follower.FollowerConstants;
 import com.pedropathing.ftc.drivetrains.Mecanum;
@@ -14,7 +13,6 @@ import com.qualcomm.robotcore.hardware.HardwareMap;
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.drive.DriveBaseMotorConfig;
 
-@Configurable
 public class Constants {
     public static double DEFAULT_MAX_POWER = 1.0;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/pedroPathing/Tuning.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/pedroPathing/Tuning.java
@@ -7,9 +7,6 @@ import static org.firstinspires.ftc.teamcode.drive.pedroPathing.Tuning.follower;
 import static org.firstinspires.ftc.teamcode.drive.pedroPathing.Tuning.stopRobot;
 import static org.firstinspires.ftc.teamcode.drive.pedroPathing.Tuning.telemetryM;
 
-import com.bylazar.configurables.PanelsConfigurables;
-import com.bylazar.configurables.annotations.Configurable;
-import com.bylazar.configurables.annotations.IgnoreConfigurable;
 import com.bylazar.field.FieldManager;
 import com.bylazar.field.PanelsField;
 import com.bylazar.field.Style;
@@ -33,18 +30,14 @@ import java.util.List;
  * @author Baron Henderson - 20077 The Indubitables
  * @version 1.0, 6/26/2025
  */
-@Configurable
 @TeleOp(name = "Tuning", group = "Pedro Pathing")
 public class Tuning extends SelectableOpMode {
     public static Follower follower;
 
-    @IgnoreConfigurable
     static PoseHistory poseHistory;
 
-    @IgnoreConfigurable
     static TelemetryManager telemetryM;
 
-    @IgnoreConfigurable
     static ArrayList<String> changes = new ArrayList<>();
 
     public Tuning() {
@@ -80,7 +73,6 @@ public class Tuning extends SelectableOpMode {
     public void onSelect() {
         if (follower == null) {
             follower = Constants.createFollower(hardwareMap);
-            PanelsConfigurables.INSTANCE.refreshClass(this);
         } else {
             follower = Constants.createFollower(hardwareMap);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/ColorMatchConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/ColorMatchConfig.java
@@ -1,12 +1,10 @@
 package org.firstinspires.ftc.teamcode.hardware;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.utilities.PersistentStorage;
 
 /**
  * Front color sensor profile used by all scoring color matching.
  */
-@Configurable
 public class ColorMatchConfig {
     private static final String PERSISTENCE_KEY = "color_match_profiles_front_v2";
     private static boolean persistedConfigLoaded = false;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/SmartCameraColorSensor.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/SmartCameraColorSensor.java
@@ -2,9 +2,9 @@ package org.firstinspires.ftc.teamcode.hardware;
 
 import android.util.Size;
 import androidx.annotation.NonNull;
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.teamcode.hardware.filters.DataFilter;
 import org.firstinspires.ftc.teamcode.hardware.filters.RollingAverage;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 import org.firstinspires.ftc.vision.VisionPortal;
 import org.firstinspires.ftc.vision.opencv.ImageRegion;
 import org.firstinspires.ftc.vision.opencv.PredominantColorProcessor;
@@ -15,17 +15,12 @@ import java.util.Arrays;
  * Wraps a SmartCamera + PredominantColorProcessor so a camera can be used like a color sensor.
  * Provides both the SDK swatch match and SmartColorSensor HSV-based scoring color match.
  */
-@Configurable
 public class SmartCameraColorSensor extends Device implements AutoCloseable, ScoringColorSensor {
-    public static int HSV_HUE_FILTER_WINDOW = 0;
-    public static int HSV_SATURATION_FILTER_WINDOW = 0;
-    public static int HSV_VALUE_FILTER_WINDOW = 0;
-
     private static final PredominantColorProcessor.Swatch[] DEFAULT_SWATCHES = {
             PredominantColorProcessor.Swatch.ARTIFACT_GREEN,
             PredominantColorProcessor.Swatch.ARTIFACT_PURPLE
     };
-    public static ImageRegion DEFAULT_ROI = ImageRegion.asUnityCenterCoordinates(-0.6, 0.6, 0.6, -0.6);
+    private static final ImageRegion DEFAULT_ROI = ImageRegion.asUnityCenterCoordinates(-0.6, 0.6, 0.6, -0.6);
 
     private final SmartCamera camera;
     private final ColorMatchConfig.ColorMatchProfile colorProfile;
@@ -172,9 +167,9 @@ public class SmartCameraColorSensor extends Device implements AutoCloseable, Sco
     }
 
     private void syncConfiguredFilters() {
-        int hueWindow = Math.max(0, HSV_HUE_FILTER_WINDOW);
-        int saturationWindow = Math.max(0, HSV_SATURATION_FILTER_WINDOW);
-        int valueWindow = Math.max(0, HSV_VALUE_FILTER_WINDOW);
+        int hueWindow = Math.max(0, LiveMatchTuning.cameraColorSensorHueFilterWindow);
+        int saturationWindow = Math.max(0, LiveMatchTuning.cameraColorSensorSaturationFilterWindow);
+        int valueWindow = Math.max(0, LiveMatchTuning.cameraColorSensorValueFilterWindow);
 
         if (hueWindow != appliedHueFilterWindow) {
             hueFilter = hueWindow == 0 ? DataFilter.NONE : new RollingAverage(hueWindow);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/SmartColorSensor.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/SmartColorSensor.java
@@ -2,21 +2,16 @@ package org.firstinspires.ftc.teamcode.hardware;
 
 import android.graphics.Color;
 import androidx.annotation.NonNull;
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.hardware.DistanceSensor;
 import com.qualcomm.robotcore.hardware.NormalizedColorSensor;
 import com.qualcomm.robotcore.hardware.NormalizedRGBA;
 import org.firstinspires.ftc.teamcode.hardware.filters.DataFilter;
 import org.firstinspires.ftc.teamcode.hardware.filters.RollingAverage;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.jetbrains.annotations.NotNull;
 
-@Configurable
 public class SmartColorSensor extends Device implements NormalizedColorSensor, Caching, ScoringColorSensor, WrappedDevice<NormalizedColorSensor> {
-    public static int HSV_HUE_FILTER_WINDOW = 0;
-    public static int HSV_SATURATION_FILTER_WINDOW = 0;
-    public static int HSV_VALUE_FILTER_WINDOW = 0;
-
     private final NormalizedColorSensor colorSensor;
     private final HardwareCache<NormalizedRGBA> colorCache;
     private final ColorMatchConfig.ColorMatchProfile colorProfile;
@@ -223,9 +218,9 @@ public class SmartColorSensor extends Device implements NormalizedColorSensor, C
     }
 
     private void syncConfiguredFilters() {
-        int hueWindow = Math.max(0, HSV_HUE_FILTER_WINDOW);
-        int saturationWindow = Math.max(0, HSV_SATURATION_FILTER_WINDOW);
-        int valueWindow = Math.max(0, HSV_VALUE_FILTER_WINDOW);
+        int hueWindow = Math.max(0, LiveMatchTuning.colorSensorHueFilterWindow);
+        int saturationWindow = Math.max(0, LiveMatchTuning.colorSensorSaturationFilterWindow);
+        int valueWindow = Math.max(0, LiveMatchTuning.colorSensorValueFilterWindow);
 
         if (hueWindow != appliedHueFilterWindow) {
             hueFilter = hueWindow == 0 ? DataFilter.NONE : new RollingAverage(hueWindow);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/SmartLimelight3A.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/SmartLimelight3A.java
@@ -1,11 +1,11 @@
 package org.firstinspires.ftc.teamcode.hardware;
 
-import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.hardware.limelightvision.LLResult;
 import com.qualcomm.hardware.limelightvision.LLResultTypes;
 import com.qualcomm.hardware.limelightvision.LLStatus;
 import com.qualcomm.hardware.limelightvision.Limelight3A;
 import org.firstinspires.ftc.robotcore.external.navigation.Pose3D;
+import org.firstinspires.ftc.teamcode.utilities.LiveMatchTuning;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -18,8 +18,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-@Configurable
-
 public class SmartLimelight3A extends Device implements Caching, WrappedDevice<Limelight3A> {
     private static final Logger log = LoggerFactory.getLogger(SmartLimelight3A.class);
     private static final long WARN_THROTTLE_MS = 1000;
@@ -29,9 +27,6 @@ public class SmartLimelight3A extends Device implements Caching, WrappedDevice<L
     private final HardwareCache<LLStatus> statusCache;
     private long lastResultWarnMs = 0;
     private long lastStatusWarnMs = 0;
-    public static double cameraOnTurretRightOffsetMeters = 0.15;
-    public static double cameraOnTurretForwardOffsetMeters = 0;
-
     public SmartLimelight3A(String configName, Limelight3A limelight) {
         super(configName);
         this.limelight = limelight;
@@ -431,12 +426,12 @@ public class SmartLimelight3A extends Device implements Caching, WrappedDevice<L
 
         public double getTagYInTurretFrameMeters() {
             if (tagInCameraPose == null) throw new IllegalStateException("Pose not set");
-            return tagInCameraPose.getPosition().y + cameraOnTurretRightOffsetMeters;
+            return tagInCameraPose.getPosition().y + LiveMatchTuning.limelightCameraOnTurretRightOffsetMeters;
         }
 
         public double getTagZInTurretFrameMeters() {
             if (tagInCameraPose == null) throw new IllegalStateException("Pose not set");
-            return tagInCameraPose.getPosition().z + cameraOnTurretForwardOffsetMeters;
+            return tagInCameraPose.getPosition().z + LiveMatchTuning.limelightCameraOnTurretForwardOffsetMeters;
         }
 
         @NotNull

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/LiveMatchTuning.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/LiveMatchTuning.java
@@ -1,0 +1,114 @@
+package org.firstinspires.ftc.teamcode.utilities;
+
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * The only intended Control Hub Configurables surface.
+ *
+ * Keep this class scalar-only. Configurables recursively serializes public
+ * static fields from annotated classes during Sloth load, so object, enum,
+ * array, collection, and runtime hardware fields belong elsewhere.
+ */
+@Configurable
+public final class LiveMatchTuning {
+    private LiveMatchTuning() {}
+
+    public static boolean runTeleOpFcs = true;
+    public static double matchStateFreshnessMs = 10000;
+    public static double teleOpMatchStateSaveIntervalMs = 500;
+    public static double teleOpFollowerMaxPower = 1.0;
+    public static String defaultAllianceColor = "BLUE";
+    public static double indexerZeroBumpTicksPerTriggerUnit = 20.0;
+    public static double turretZeroBumpTicksPerTriggerUnit = -200.0;
+    public static double maintenancePoseTrimInchesPerTouchpadUnit = 12.0;
+    public static double manualAimDegreesPerSecond = 75.0;
+    public static double manualAimStickDeadband = 0.08;
+
+    public static double farFiringTaskBaseBlueXIn = -55.5;
+    public static double farFiringTaskBaseBlueYIn = -48;
+    public static double farFiringTaskBaseBlueHeadingDeg = -105;
+    public static double farFiringTaskBaseRedXIn = -55.5;
+    public static double farFiringTaskBaseRedYIn = 48;
+    public static double farFiringTaskBaseRedHeadingDeg = 105;
+    public static double farFiringTaskDriveToBaseTimeoutSec = 4.0;
+    public static double farFiringTaskWaitForFullTimeoutSec = 10.0;
+    public static double farFiringTaskReturnTimeoutSec = 4.0;
+    public static double farFiringTaskReadyToFireTimeoutSec = 4.0;
+    public static double farFiringTaskStorageDrainTimeoutSec = 10.0;
+    public static double farFiringTaskRepeatDelaySec = 0.5;
+    public static double driverOverrideDeadband = 0.08;
+
+    public static double fcsBaseVelocity = 2700;
+    public static double fcsVelocityPerMeter = 620;
+    public static double fcsMinVelocity = 3500;
+    public static double fcsMaxVelocity = 5000;
+    public static double fcsHoodBasePosition = 0.53;
+    public static double fcsHoodPositionPerMeter = 0.1;
+    public static boolean fcsUseDepotPoseFallbackWhenTagNotVisible = true;
+    public static double fcsAlignedButLauncherOffHueDeg = 145.0;
+    public static double blueDepotX = 59;
+    public static double blueDepotY = 57;
+    public static double redDepotX = 59;
+    public static double redDepotY = -57;
+    public static double fcsTurretToleranceDeg = 3;
+
+    public static double turretKp = 0.02;
+    public static double turretKi = 0;
+    public static double turretKd = 0.015;
+    public static double turretKf = 0;
+    public static double turretToleranceDeg = 1;
+    public static double turretTicksPerDegree = (8192.0 / 360.0) * (88.0 / 20.0);
+    public static double turretMinAngleDeg = -90;
+    public static double turretMaxAngleDeg = 90;
+
+    public static double launcherKp = 0.002;
+    public static double launcherKi = 0;
+    public static double launcherKd = 0;
+    public static double launcherKf = 0.00025;
+    public static double launcherKv = 0.03;
+    public static double launcherTolerance = 30;
+    public static double launcherMaxVoltage = 14;
+    public static double launcherTicksPerDegree = 112.0 / 360.0;
+
+    public static double indexerKp = 0.007;
+    public static double indexerKi = 0;
+    public static double indexerKd = 0.0075;
+    public static double indexerKf = 0.000005;
+    public static double indexerToleranceDeg = 1;
+    public static double indexerBusyToleranceDeg = 2.5;
+    public static double indexerPoweredMovePower = 1;
+    public static double indexerTicksPerDegree = 8192.0 / 360.0;
+
+    public static double limelightLocalizerCameraX = 0;
+    public static double limelightLocalizerCameraY = 0;
+    public static double limelightLocalizerCameraZ = 0;
+    public static double limelightLocalizerCameraHeadingDeg = 0;
+    public static double blueDepotHeadingDeg = -40;
+    public static double redDepotHeadingDeg = 40;
+    public static double limelightCameraOnTurretRightOffsetMeters = 0.15;
+    public static double limelightCameraOnTurretForwardOffsetMeters = 0;
+
+    public static double feedRampMin = 0;
+    public static double feedRampMax = 1;
+    public static double feedRampEngagedPosition = 0.32;
+    public static double feedRampDisengagedPosition = 1;
+    public static double feedWheelPower = 1;
+
+    public static int requiredConsecutiveContentReads = 1;
+    public static double frontSensorMinDistance = 38;
+    public static double greenHue = 159.0;
+    public static double purpleHue = 170.0;
+    public static int colorSensorHueFilterWindow = 0;
+    public static int colorSensorSaturationFilterWindow = 0;
+    public static int colorSensorValueFilterWindow = 0;
+    public static int cameraColorSensorHueFilterWindow = 0;
+    public static int cameraColorSensorSaturationFilterWindow = 0;
+    public static int cameraColorSensorValueFilterWindow = 0;
+
+    public static double volleyFirePrepareTimeMs = 250;
+    public static double volleyFireEndTimeMs = 350;
+    public static boolean volleyJamCorrectingEnabled = true;
+    public static double volleyJamCorrectingTimeThresholdMs = 300;
+    public static double volleyJamCorrectingVelocityThreshold = 25;
+    public static double volleyJamCorrectingTimeMs = 1000;
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/MatchStateStore.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/MatchStateStore.java
@@ -1,14 +1,20 @@
 package org.firstinspires.ftc.teamcode.utilities;
 
 import androidx.annotation.Nullable;
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.teamcode.components.mechanisms.DriveBase;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Indexer;
 import org.firstinspires.ftc.teamcode.components.subsystems.IndexerStorage;
+import org.firstinspires.ftc.teamcode.core.OpModeCore;
 import org.firstinspires.ftc.teamcode.components.mechanisms.Turret;
 import org.firstinspires.ftc.teamcode.hardware.SmartLimelight3A;
 
 public final class MatchStateStore {
     private static final String SNAPSHOT_KEY = "match_state_snapshot_v1";
+    private static Snapshot latestLiveSnapshot;
+    private static Snapshot latestPersistentSnapshot;
+    private static ModeKind latestLiveSnapshotSource = ModeKind.UNKNOWN;
 
     private MatchStateStore() {}
 
@@ -48,12 +54,8 @@ public final class MatchStateStore {
             AllianceColor allianceColor,
             @Nullable SmartLimelight3A.AprilTag obeliskTag
     ) {
-        if (!PersistentStorage.isInitialized()) {
-            return;
-        }
-
         Snapshot snapshot = new Snapshot();
-        Snapshot previous = getLatestSnapshot();
+        Snapshot previous = getLatestSnapshotForCarryForward();
         snapshot.savedAtUnixMs = System.currentTimeMillis();
         snapshot.allianceColor = allianceColor.name();
 
@@ -91,15 +93,25 @@ public final class MatchStateStore {
             snapshot.obeliskSeenAtUnixMs = snapshot.savedAtUnixMs;
         }
 
-        PersistentStorage.saveObject(SNAPSHOT_KEY, snapshot);
+        ModeKind currentModeKind = getCurrentModeKind();
+        latestLiveSnapshot = snapshot;
+        latestLiveSnapshotSource = currentModeKind;
+        if (shouldPersistForMode(currentModeKind)) {
+            savePersistentSnapshot(snapshot);
+        }
     }
 
     @Nullable
     public static Snapshot getLatestSnapshot() {
-        if (!PersistentStorage.isInitialized()) {
-            return null;
+        if (shouldUseLiveSnapshotForCurrentOpMode()) {
+            if (latestLiveSnapshot != null && latestLiveSnapshotSource == ModeKind.AUTONOMOUS) {
+                return latestLiveSnapshot;
+            }
+            if (latestPersistentSnapshot != null) {
+                return latestPersistentSnapshot;
+            }
         }
-        return PersistentStorage.getObject(SNAPSHOT_KEY, Snapshot.class);
+        return getStoredSnapshot();
     }
 
     @Nullable
@@ -151,9 +163,79 @@ public final class MatchStateStore {
     }
 
     public static void clear() {
-        if (!PersistentStorage.isInitialized()) {
-            return;
+        latestLiveSnapshot = null;
+        latestPersistentSnapshot = null;
+        latestLiveSnapshotSource = ModeKind.UNKNOWN;
+        if (PersistentStorage.isInitialized()) {
+            PersistentStorage.remove(SNAPSHOT_KEY);
         }
-        PersistentStorage.remove(SNAPSHOT_KEY);
+    }
+
+    @Nullable
+    private static Snapshot getStoredSnapshot() {
+        if (!PersistentStorage.isInitialized()) {
+            return null;
+        }
+        latestPersistentSnapshot = PersistentStorage.getObject(SNAPSHOT_KEY, Snapshot.class);
+        return latestPersistentSnapshot;
+    }
+
+    private static void savePersistentSnapshot(Snapshot snapshot) {
+        latestPersistentSnapshot = snapshot;
+        if (PersistentStorage.isInitialized()) {
+            PersistentStorage.saveObject(SNAPSHOT_KEY, snapshot);
+        }
+    }
+
+    private static boolean shouldPersistForMode(ModeKind modeKind) {
+        return modeKind == ModeKind.AUTONOMOUS;
+    }
+
+    private static boolean shouldUseLiveSnapshotForCurrentOpMode() {
+        return getCurrentModeKind() == ModeKind.TELEOP;
+    }
+
+    private static ModeKind getCurrentModeKind() {
+        OpModeCore opMode = OpModeCore.getInstance();
+        if (opMode == null) {
+            return ModeKind.UNKNOWN;
+        }
+
+        ModeKind annotatedMode = getAnnotatedModeKind(opMode.getClass());
+        if (annotatedMode != ModeKind.UNKNOWN) {
+            return annotatedMode;
+        }
+        return ModeKind.UNKNOWN;
+    }
+
+    @Nullable
+    private static Snapshot getLatestSnapshotForCarryForward() {
+        if (latestLiveSnapshot != null) {
+            return latestLiveSnapshot;
+        }
+        if (latestPersistentSnapshot != null) {
+            return latestPersistentSnapshot;
+        }
+        return getStoredSnapshot();
+    }
+
+    private static ModeKind getAnnotatedModeKind(@Nullable Class<?> opModeClass) {
+        Class<?> current = opModeClass;
+        while (current != null) {
+            if (current.isAnnotationPresent(TeleOp.class)) {
+                return ModeKind.TELEOP;
+            }
+            if (current.isAnnotationPresent(Autonomous.class)) {
+                return ModeKind.AUTONOMOUS;
+            }
+            current = current.getSuperclass();
+        }
+        return ModeKind.UNKNOWN;
+    }
+
+    private enum ModeKind {
+        TELEOP,
+        AUTONOMOUS,
+        UNKNOWN
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/RollingPercentileWindow.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/RollingPercentileWindow.java
@@ -1,0 +1,113 @@
+package org.firstinspires.ftc.teamcode.utilities;
+
+import org.firstinspires.ftc.teamcode.hardware.filters.DataFilter;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+
+/**
+ * Maintains a rolling window of samples and computes percentiles on demand.
+ */
+public class RollingPercentileWindow implements DataFilter {
+    private int maxSize;
+    private double trackedPercentile;
+    private final ArrayDeque<Double> values;
+
+    public RollingPercentileWindow(int maxSize) {
+        this(maxSize, 50);
+    }
+
+    public RollingPercentileWindow(int maxSize, double trackedPercentile) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("maxSize must be greater than 0");
+        }
+        this.maxSize = maxSize;
+        this.trackedPercentile = trackedPercentile;
+        this.values = new ArrayDeque<>(maxSize);
+    }
+
+    public void add(double value) {
+        if (values.size() >= maxSize) {
+            values.pollFirst();
+        }
+        values.addLast(value);
+    }
+
+    public int size() {
+        return values.size();
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    public double getTrackedPercentile() {
+        return trackedPercentile;
+    }
+
+    public void setTrackedPercentile(double trackedPercentile) {
+        this.trackedPercentile = trackedPercentile;
+    }
+
+    public void setMaxSize(int newMaxSize) {
+        if (newMaxSize <= 0) {
+            throw new IllegalArgumentException("maxSize must be greater than 0");
+        }
+        this.maxSize = newMaxSize;
+        while (values.size() > maxSize) {
+            values.pollFirst();
+        }
+    }
+
+    @Override
+    public double compute(double newValue) {
+        add(newValue);
+        return getPercentile(trackedPercentile);
+    }
+
+    public double getPercentile(double percentile) {
+        if (values.isEmpty()) {
+            return 0.0;
+        }
+
+        double[] sorted = new double[values.size()];
+        int index = 0;
+        for (double value : values) {
+            sorted[index++] = value;
+        }
+        Arrays.sort(sorted);
+
+        if (percentile <= 0) {
+            return sorted[0];
+        }
+        if (percentile >= 100) {
+            return sorted[sorted.length - 1];
+        }
+
+        double rank = (percentile / 100.0) * (sorted.length - 1);
+        int lowerIndex = (int) Math.floor(rank);
+        int upperIndex = (int) Math.ceil(rank);
+        if (lowerIndex == upperIndex) {
+            return sorted[lowerIndex];
+        }
+
+        double lowerValue = sorted[lowerIndex];
+        double upperValue = sorted[upperIndex];
+        double blend = rank - lowerIndex;
+        return lowerValue + ((upperValue - lowerValue) * blend);
+    }
+
+    public double getMax() {
+        if (values.isEmpty()) {
+            return 0.0;
+        }
+
+        double max = Double.NEGATIVE_INFINITY;
+        for (double value : values) {
+            if (value > max) {
+                max = value;
+            }
+        }
+        return max;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/RollingPercentileWindow.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utilities/RollingPercentileWindow.java
@@ -69,14 +69,32 @@ public class RollingPercentileWindow implements DataFilter {
         if (values.isEmpty()) {
             return 0.0;
         }
+        return percentileFromSorted(sortedSnapshot(), percentile);
+    }
 
+    public double[] getPercentiles(double... percentiles) {
+        double[] result = new double[percentiles.length];
+        if (values.isEmpty()) {
+            return result;
+        }
+        double[] sorted = sortedSnapshot();
+        for (int i = 0; i < percentiles.length; i++) {
+            result[i] = percentileFromSorted(sorted, percentiles[i]);
+        }
+        return result;
+    }
+
+    private double[] sortedSnapshot() {
         double[] sorted = new double[values.size()];
         int index = 0;
         for (double value : values) {
             sorted[index++] = value;
         }
         Arrays.sort(sorted);
+        return sorted;
+    }
 
+    private static double percentileFromSorted(double[] sorted, double percentile) {
         if (percentile <= 0) {
             return sorted[0];
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/AprilTagReader.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/AprilTagReader.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.vision;
 
-import com.bylazar.configurables.annotations.Configurable;
 import org.firstinspires.ftc.robotcore.external.hardware.camera.BuiltinCameraDirection;
 import org.firstinspires.ftc.teamcode.hardware.SmartCamera;
 import org.firstinspires.ftc.teamcode.utilities.Pose;
@@ -11,7 +10,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Configurable
 public class AprilTagReader {
 
 

--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -3,6 +3,8 @@ repositories {
     google() // Needed for androidx
     maven { url = 'https://maven.brott.dev/' }
     maven { url = "https://mymaven.bylazar.com/releases" }
+    maven { url = "https://repo.dairy.foundation/releases" }
+    maven { url = "https://repo.dairy.foundation/snapshots" }
 }
 
 dependencies {
@@ -19,6 +21,6 @@ dependencies {
     implementation 'com.pedropathing:ftc:2.0.4'
     implementation 'com.pedropathing:telemetry:1.0.0'
 
-    implementation 'com.bylazar:fullpanels:1.0.12'
+    implementation "dev.frozenmilk.sinister:Sloth:0.2.4"
+    implementation "com.bylazar.sloth:fullpanels:0.2.4+1.0.12"
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,12 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        maven { url "https://repo.dairy.foundation/releases" }
     }
     dependencies {
         // Note for FTC Teams: Do not modify this yourself.
         classpath 'com.android.tools.build:gradle:8.7.0'
+        classpath "dev.frozenmilk:Load:0.2.4"
     }
 }
 
@@ -21,9 +23,14 @@ allprojects {
     repositories {
         mavenCentral()
         google()
+        maven { url "https://repo.dairy.foundation/releases" }
+        maven { url "https://repo.dairy.foundation/snapshots" }
     }
 }
 
 repositories {
     mavenCentral()
+    google()
+    maven { url "https://repo.dairy.foundation/releases" }
+    maven { url "https://repo.dairy.foundation/snapshots" }
 }


### PR DESCRIPTION
## What
**1. Auto→TeleOp hand-off (`MatchStateStore`)** — auto now owns the persisted snapshot; teleop reads it but no longer overwrites it.
- Before: every save (auto *and* teleop) hit disk, so teleop's live pose continuously clobbered auto's hand-off state.
- After: only auto persists. Teleop reads auto's snapshot — in-memory in the same session, from disk after an app restart.

**2. Loop-timing telemetry (`MainTeleOp` + new `RollingPercentileWindow`)** — replaces the single rolling-avg "Tick Time" with P50/P95/P99/max, so loop spikes (e.g. the periodic state-save) are visible.

## ⚠️ One thing to confirm
TeleOp no longer persists match state to disk — only auto does. Intended? (A mid-teleop crash would fall back to the auto snapshot — almost certainly what we want, just flagging it.)

## Note
The CME the middle commit fixes was introduced earlier *in this same PR* (percentile lambdas iterated the sample deque on the Panels thread). Net diff is clean.
